### PR TITLE
Replace node-webkit builder with nw-builder

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -45,13 +45,14 @@ module.exports = function(grunt) {
             }
         },
 
-        nodewebkit: {
+        nwjs: {
             win: {
                 options: {
                     name: 'Ghost Updater for Azure',
                     platforms: ['win'],
                     buildDir: './builds',
-                    winIco: './public/images/icon.ico'
+                    winIco: './public/images/icon.ico',
+                    version: '0.12.2'
                 },
                 src: ['public/**/*', 'node_modules/**/*', '!node_modules/grunt**/**', 'updater/**/*', 'updater_client/**/*', 'views/**/*', '*.js', '*.html', '*.json'] // Your node-webkit app
             },
@@ -72,13 +73,13 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-contrib-jshint');
     grunt.loadNpmTasks('grunt-contrib-concat');
     grunt.loadNpmTasks('grunt-contrib-watch');
-    grunt.loadNpmTasks('grunt-node-webkit-builder');
+    grunt.loadNpmTasks('grunt-nw-builder');
     grunt.loadNpmTasks('grunt-concurrent');
     grunt.loadNpmTasks('grunt-nodemon');
 
     grunt.registerTask('test', ['jshint']);
-    grunt.registerTask('buildwin', ['concat', 'nodewebkit:win']);
-    grunt.registerTask('buildunix', ['concat', 'nodewebkit:unix']);
+    grunt.registerTask('buildwin', ['concat', 'nwjs:win']);
+    grunt.registerTask('buildunix', ['concat', 'nwjs:unix']);
     grunt.registerTask('buildandrun', ['concat', 'nodemon']);
     grunt.registerTask('dev', ['concat', 'concurrent']);
     grunt.registerTask('default', ['jshint']);

--- a/package.json
+++ b/package.json
@@ -33,8 +33,9 @@
     "grunt-contrib-concat": "^0.5.0",
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-watch": "^0.6.1",
-    "grunt-node-webkit-builder": "^0.2.3",
-    "grunt-nodemon": "^0.3.0"
+    "grunt-nodemon": "^0.3.0",
+    "grunt-nw-builder": "^2.0.0",
+    "jshint": "^2.9.1"
   },
   "window": {
     "title": "Ghost Updater for Azure Websites",
@@ -46,10 +47,8 @@
     "resizable": false,
     "position": "center"
   },
-  "repositories": [
-    {
-      "type": "git",
-      "url": "https://github.com/felixrieseberg/Ghost-Updater-Azure.git"
-    }
-  ]
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/felixrieseberg/Ghost-Updater-Azure.git"
+  }
 }


### PR DESCRIPTION
During `npm install`, saw the following

```
npm WARN deprecated grunt-node-webkit-builder@0.2.3: WARNING: This module has been renamed to grunt-nw-builder. Install using grunt-nw-builder instead, grunt-node-webkit-builder will no longer be updated.
```

Which I ignored until when trying to `buildwin`, I got the following error. 

```
λ grunt buildwin
Running "concat:dist" (concat) task
File public/scripts/built.js created.

Running "nodewebkit:win" (nodewebkit) task
Latest Version: v0.13.0
Using v0.13.0
Create cache folder in C:\Source\GitHub\Ghost-Updater-Azure\cache\0.13.0
Downloading: http://dl.node-webkit.org/v0.13.0/node-webkit-v0.13.0-win-ia32.zip
undefined
Fatal error: Unable to download nodewebkit.
```

So I have replaced `grunt-node-webkit-builder` and `grunt-nw-builder`.

Needed to fix the `nwjs` version to `0.12.2` due to https://github.com/nwjs/nw-builder/issues/252 

I haven't been able to test the linux and OSX platforms. Might need to fix the `nwjs` version.
